### PR TITLE
fix(category-list): fix icon with vs-seti icon theme

### DIFF
--- a/src/services/check-workspace.ts
+++ b/src/services/check-workspace.ts
@@ -1,4 +1,5 @@
 import { commands, workspace } from 'vscode';
+import { refreshPostCategoriesList } from '../commands/post-category/refresh-post-categories-list';
 import { globalState } from './global-state';
 import { PostFileMapManager } from './post-file-map';
 import { Settings } from './settings.service';
@@ -12,9 +13,14 @@ export const isTargetWorkspace = (): boolean => {
 
 export const observeConfigurationChange = () => {
     globalState.extensionContext?.subscriptions.push(
-        workspace.onDidChangeConfiguration(ev =>
-            ev.affectsConfiguration(Settings.prefix) ? isTargetWorkspace() : false
-        )
+        workspace.onDidChangeConfiguration(ev => {
+            if (ev.affectsConfiguration(Settings.prefix)) {
+                isTargetWorkspace();
+            }
+            if (ev.affectsConfiguration(`${Settings.iconThemePrefix}.${Settings.iconThemeKey}`)) {
+                refreshPostCategoriesList();
+            }
+        })
     );
     isTargetWorkspace();
 };

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -7,6 +7,20 @@ export class Settings {
         return `cnblogsClientForVSCode`;
     }
 
+    static get iconThemePrefix() {
+        return 'workbench';
+    }
+
+    static get iconThemeKey() {
+        return `iconTheme`;
+    }
+
+    static get iconTheme() {
+        return <'vs-seti' | 'vs-minimal' | undefined | string>(
+            workspace.getConfiguration(this.iconThemePrefix).get<string>(this.iconThemeKey)
+        );
+    }
+
     static get configuration() {
         return workspace.getConfiguration(this.prefix);
     }

--- a/src/tree-view-providers/categories-view-data-provider.ts
+++ b/src/tree-view-providers/categories-view-data-provider.ts
@@ -2,6 +2,18 @@ import { commands, Event, EventEmitter, MessageOptions, ThemeIcon, TreeDataProvi
 import { PostCategories, PostCategory } from '../models/post-category';
 import { globalState } from '../services/global-state';
 import { postCategoryService } from '../services/post-category.service';
+import { Settings } from '../services/settings.service';
+
+const categoryIcon = () => {
+    const iconTheme = Settings.iconTheme;
+    let iconId = 'folder';
+    switch (iconTheme) {
+        case 'vs-seti':
+            iconId = 'file-directory';
+            break;
+    }
+    return new ThemeIcon(iconId);
+};
 
 export class PostCategoriesViewDataProvider implements TreeDataProvider<PostCategory> {
     private static _instance: PostCategoriesViewDataProvider;
@@ -36,7 +48,7 @@ export class PostCategoriesViewDataProvider implements TreeDataProvider<PostCate
     getTreeItem(element: PostCategory): TreeItem | Thenable<TreeItem> {
         const label = `${element.title}(${element.count})`;
         return Object.assign(new TreeItem(label), {
-            iconPath: new ThemeIcon('folder'),
+            iconPath: categoryIcon(),
             contextValue: 'cnb-post-category',
         } as TreeItem);
     }


### PR DESCRIPTION
修复使用 `vs-seti`  图标主题时分类列表没有图标

<img width="981" alt="image" src="https://user-images.githubusercontent.com/38829279/159649990-37eb53e6-9ad0-45cc-b4d9-72538eb0faa4.png">
