### PR TITLE
feat: add setting - saveWithC

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,6 +255,13 @@
                         "type": "string",
                         "editPresentation": "singlelineText",
                         "markdownDescription": "Chromium可执行文件路径, 用于进行pdf导出等操作"
+                    },
+                    "cnblogsClientForVSCode.saveWithC": {
+                        "order": 3,
+                        "default": true,
+                        "scope": "application",
+                        "type": "boolean",
+                        "markdownDescription": "设置是否根据博文分类保存到不同的文件夹中"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
                         "editPresentation": "singlelineText",
                         "markdownDescription": "Chromium可执行文件路径, 用于进行pdf导出等操作"
                     },
-                    "cnblogsClientForVSCode.saveWithC": {
+                    "cnblogsClientForVSCode.createLocalPostFileWithCategory": {
                         "order": 3,
                         "default": true,
                         "scope": "application",

--- a/src/commands/post-category/update-post-category.ts
+++ b/src/commands/post-category/update-post-category.ts
@@ -34,12 +34,12 @@ export const updatePostCategory = async (category?: PostCategory) => {
             try {
                 await postCategoryService.updateCategory(updateDto);
                 refreshPostCategoriesList();
-                // 如果选择了saveWithC模式且本地有该目录,则重命名该目录
+                // 如果选择了createLocalPostFileWithCategory模式且本地有该目录,则重命名该目录
                 const workspaceUri = Settings.workspaceUri;
-                const saveWithC = Settings.saveWithC;
+                const createLocalPostFileWithCategory = Settings.createLocalPostFileWithCategory;
                 const uri = Uri.joinPath(workspaceUri, category.title).fsPath;
                 const isFileExist = fs.existsSync(uri);
-                if (saveWithC && isFileExist) {
+                if (createLocalPostFileWithCategory && isFileExist) {
                     const oldUri = Uri.joinPath(workspaceUri, category.title);
                     const newUri = Uri.joinPath(workspaceUri, addDto.title);
                     await workspace.fs.rename(oldUri, newUri);

--- a/src/commands/posts-list/open-post-in-vscode.ts
+++ b/src/commands/posts-list/open-post-in-vscode.ts
@@ -8,13 +8,22 @@ import { PostFileMapManager } from '../../services/post-file-map';
 import { Settings } from '../../services/settings.service';
 import { openPostFile } from './open-post-file';
 import { PostTitleSanitizer } from '../../services/post-title-sanitizer.service';
+import { postCategoryService } from '../../services/post-category.service';
 
 const buildLocalPostFileUri = async (post: Post, includePostId = false): Promise<Uri> => {
     const workspaceUri = Settings.workspaceUri;
+    const saveWithC = Settings.saveWithC;
     const ext = `.${post.isMarkdown ? 'md' : 'html'}`;
     const postIdSegment = includePostId ? `.${post.id}` : '';
     const { text: postTitle } = await PostTitleSanitizer.sanitize(post);
-    return Uri.joinPath(workspaceUri, `${postTitle}${postIdSegment}${ext}`);
+    if (saveWithC) {
+        let categories = await postCategoryService.fetchCategories();
+        categories = categories.filter(x => post.categoryIds?.includes(x.categoryId));
+        const categoryTitle = categories.length > 0 ? categories.map(c => c.title).join(',') : '未分类';
+        return Uri.joinPath(workspaceUri, categoryTitle, `${postTitle}${postIdSegment}${ext}`);
+    } else {
+        return Uri.joinPath(workspaceUri, `${postTitle}${postIdSegment}${ext}`);
+    }
 };
 
 export const openPostInVscode = async (postId: number, forceUpdateLocalPostFile = false): Promise<Uri | false> => {

--- a/src/commands/posts-list/open-post-in-vscode.ts
+++ b/src/commands/posts-list/open-post-in-vscode.ts
@@ -19,7 +19,7 @@ const buildLocalPostFileUri = async (post: Post, includePostId = false): Promise
     if (createLocalPostFileWithCategory) {
         let categories = await postCategoryService.fetchCategories();
         categories = categories.filter(x => post.categoryIds?.includes(x.categoryId));
-        const categoryTitle = categories.length > 0 ? categories.map(c => c.title).join(',') : '';
+        const categoryTitle = categories[0]?.title ?? '';
         return Uri.joinPath(workspaceUri, categoryTitle, `${postTitle}${postIdSegment}${ext}`);
     } else {
         return Uri.joinPath(workspaceUri, `${postTitle}${postIdSegment}${ext}`);

--- a/src/commands/posts-list/open-post-in-vscode.ts
+++ b/src/commands/posts-list/open-post-in-vscode.ts
@@ -12,14 +12,14 @@ import { postCategoryService } from '../../services/post-category.service';
 
 const buildLocalPostFileUri = async (post: Post, includePostId = false): Promise<Uri> => {
     const workspaceUri = Settings.workspaceUri;
-    const saveWithC = Settings.saveWithC;
+    const createLocalPostFileWithCategory = Settings.createLocalPostFileWithCategory;
     const ext = `.${post.isMarkdown ? 'md' : 'html'}`;
     const postIdSegment = includePostId ? `.${post.id}` : '';
     const { text: postTitle } = await PostTitleSanitizer.sanitize(post);
-    if (saveWithC) {
+    if (createLocalPostFileWithCategory) {
         let categories = await postCategoryService.fetchCategories();
         categories = categories.filter(x => post.categoryIds?.includes(x.categoryId));
-        const categoryTitle = categories.length > 0 ? categories.map(c => c.title).join(',') : '未分类';
+        const categoryTitle = categories.length > 0 ? categories.map(c => c.title).join(',') : '';
         return Uri.joinPath(workspaceUri, categoryTitle, `${postTitle}${postIdSegment}${ext}`);
     } else {
         return Uri.joinPath(workspaceUri, `${postTitle}${postIdSegment}${ext}`);

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -67,11 +67,11 @@ export class Settings {
         await this.configuration.update(this.chromiumPathConfigurationKey, value, ConfigurationTarget.Global);
     }
 
-    static get saveWithC(): boolean {
-        return this.configuration.get<boolean>('saveWithC') ?? false;
+    static get createLocalPostFileWithCategory(): boolean {
+        return this.configuration.get<boolean>('createLocalPostFileWithCategory') ?? false;
     }
 
-    static async setSaveWithC(value: boolean) {
-        await this.configuration.update('saveWithC', value, ConfigurationTarget.Global);
+    static async setCreateLocalPostFileWithCategory(value: boolean) {
+        await this.configuration.update('createLocalPostFileWithCategory', value, ConfigurationTarget.Global);
     }
 }

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -66,4 +66,12 @@ export class Settings {
         }
         await this.configuration.update(this.chromiumPathConfigurationKey, value, ConfigurationTarget.Global);
     }
+
+    static get saveWithC(): boolean {
+        return this.configuration.get<boolean>('saveWithC') ?? false;
+    }
+
+    static async setSaveWithC(value: boolean) {
+        await this.configuration.update('saveWithC', value, ConfigurationTarget.Global);
+    }
 }


### PR DESCRIPTION
> When this setting is enabled, the user's blogs will be saved in the corresponding category folder

* feat: add setting - saveWithC

* feat: implement saveWithC function when open-post-in-vscode

* feat: implement saveWithC function when update-post-category

When a category is changed, the folder name will be renamed, if saveWithC function is enabled.