### PR TITLE
fix(auto-extract-images): fix save-to-cnblogs blocked by auto-extract-images  in some cases if enabled

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
         "@typescript-eslint/naming-convention": "warn",
         "@typescript-eslint/semi": "warn",
         "curly": "warn",
-        "eqeqeq": "warn",
+        "eqeqeq": ["warn", "smart"],
         "no-throw-literal": "warn",
         "semi": "warn",
         "require-await": "warn",


### PR DESCRIPTION
修复启用保存时自动提取图片后，保存没有可以提取图片的博文到博客园，保存过程会被阻塞在`没有可以提取的图片`的警告提示窗口的问题